### PR TITLE
Add workflow to publish Docker image to Docker Hub

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,34 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/multi-postgres:latest

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -31,4 +31,4 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/multi-postgres:latest
+          tags: ${{ secrets.DOCKER_USERNAME }}/multi-postgres:latest

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2

--- a/README.md
+++ b/README.md
@@ -82,3 +82,32 @@ services:
 ### Explanation
 
 This creates a root user named `root` with the password `password`. Two databases `db1` and `db2` are created with corresponding users `user1` and `user2`, each with their respective passwords `pass1` and `pass2`. Backups are configured to keep the last 5 backups, run daily at 2 AM.
+
+## Automated Publishing Workflow
+
+This repository includes a GitHub Actions workflow to automate the process of building and publishing the Docker image to Docker Hub.
+
+### Workflow File
+
+The workflow file is located at `.github/workflows/publish-docker-image.yml`.
+
+### Triggers
+
+The workflow is triggered on the following events:
+- Push to the `master` branch
+- Pull request to the `master` branch
+
+### Steps
+
+The workflow performs the following steps:
+1. Checkout the repository
+2. Set up Docker Buildx
+3. Log in to Docker Hub
+4. Build the Docker image using the `Dockerfile`
+5. Push the Docker image to Docker Hub
+
+### Docker Hub Credentials
+
+To use this workflow, you need to provide your Docker Hub credentials as secrets in your GitHub repository. The required secrets are:
+- `DOCKERHUB_USERNAME`: Your Docker Hub username
+- `DOCKERHUB_TOKEN`: Your Docker Hub access token

--- a/README.md
+++ b/README.md
@@ -82,32 +82,3 @@ services:
 ### Explanation
 
 This creates a root user named `root` with the password `password`. Two databases `db1` and `db2` are created with corresponding users `user1` and `user2`, each with their respective passwords `pass1` and `pass2`. Backups are configured to keep the last 5 backups, run daily at 2 AM.
-
-## Automated Publishing Workflow
-
-This repository includes a GitHub Actions workflow to automate the process of building and publishing the Docker image to Docker Hub.
-
-### Workflow File
-
-The workflow file is located at `.github/workflows/publish-docker-image.yml`.
-
-### Triggers
-
-The workflow is triggered on the following events:
-- Push to the `master` branch
-- Pull request to the `master` branch
-
-### Steps
-
-The workflow performs the following steps:
-1. Checkout the repository
-2. Set up Docker Buildx
-3. Log in to Docker Hub
-4. Build the Docker image using the `Dockerfile`
-5. Push the Docker image to Docker Hub
-
-### Docker Hub Credentials
-
-To use this workflow, you need to provide your Docker Hub credentials as secrets in your GitHub repository. The required secrets are:
-- `DOCKERHUB_USERNAME`: Your Docker Hub username
-- `DOCKERHUB_TOKEN`: Your Docker Hub access token


### PR DESCRIPTION
Add a GitHub Actions workflow to publish Docker image to Docker Hub

* **README.md**
  - Add a section on the automated publishing workflow
  - Describe the workflow file location, triggers, steps, and required Docker Hub credentials

* **.github/workflows/publish-docker-image.yml**
  - Create a new GitHub Actions workflow file
  - Trigger the workflow on push to the `master` branch and pull request to the `master` branch
  - Checkout the repository, set up Docker Buildx, log in to Docker Hub, build and push the Docker image

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ey-jo/docker-postgresql-multiple-databases/pull/1?shareId=996f3c52-3894-42a0-a5ba-c53bb9e50586).